### PR TITLE
Initialize LocalChat Android project

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,10 @@
+# AI Agent Best Practices
+
+This repository uses AI agents to assist with development tasks. Follow these principles:
+
+1. **Test-Driven Development**: Implement features guided by tests. Write tests first whenever possible.
+2. **Document Actions**: Record all noteworthy decisions and actions in `HISTORY.md`.
+3. **Write Clear Commits**: Each commit message should be concise and descriptive.
+4. **Keep Code Simple**: Aim for readability and maintainability over cleverness.
+5. **Automate When Reasonable**: Use scripts and tools to automate repetitive tasks.
+

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,0 +1,6 @@
+# Project History
+
+## [Unreleased]
+- Initial project scaffold for LocalChat Android app.
+- Added best practices for AI agents in `AGENTS.md`.
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
-# Namek
+# LocalChat
+
+LocalChat is an Android application for chatting over a local network using UDP broadcast messages. This repository is maintained with test-driven development and includes best practices for contributions using AI agents.
+
+## Getting Started
+1. Open the project in Android Studio.
+2. Build and run on devices within the same local network.
+
+## Development Guidelines
+- Follow the principles in `AGENTS.md`.
+- Document all significant changes in `HISTORY.md`.
+- Write tests before implementing features.
+
+## Roadmap
+The project is split into the following milestones:
+1. **Networking Layer**: Implement UDP broadcast sender and receiver with tests.
+2. **UI Design**: Create screens for listing messages and composing new ones.
+3. **Message Storage**: Add local persistence for chat history.
+4. **Peer Discovery**: Identify active peers on the network.
+5. **Polish**: Improve reliability and handle edge cases.
+
+Contributions should tackle these tasks incrementally.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,0 +1,34 @@
+plugins {
+    id 'com.android.application'
+    id 'kotlin-android'
+}
+
+android {
+    namespace "com.example.localchat"
+    compileSdk 33
+
+    defaultConfig {
+        applicationId "com.example.localchat"
+        minSdk 21
+        targetSdk 33
+        versionCode 1
+        versionName "1.0"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        }
+    }
+}
+
+dependencies {
+    implementation 'androidx.core:core-ktx:1.10.1'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'com.google.android.material:material:1.9.0'
+    testImplementation 'junit:junit:4.13.2'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
+}

--- a/app/src/androidTest/java/com/example/localchat/MainActivityTest.kt
+++ b/app/src/androidTest/java/com/example/localchat/MainActivityTest.kt
@@ -1,0 +1,18 @@
+package com.example.localchat
+
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class MainActivityTest {
+    @get:Rule
+    val rule = ActivityScenarioRule(MainActivity::class.java)
+
+    @Test
+    fun launch() {
+        // Ensure activity launches
+    }
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.localchat">
+
+    <application
+        android:allowBackup="true"
+        android:label="@string/app_name"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.AppCompat.Light.DarkActionBar">
+        <activity android:name=".MainActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/app/src/main/java/com/example/localchat/MainActivity.kt
+++ b/app/src/main/java/com/example/localchat/MainActivity.kt
@@ -1,0 +1,11 @@
+package com.example.localchat
+
+import androidx.appcompat.app.AppCompatActivity
+import android.os.Bundle
+
+class MainActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_main)
+    }
+}

--- a/app/src/main/java/com/example/localchat/UdpBroadcastService.kt
+++ b/app/src/main/java/com/example/localchat/UdpBroadcastService.kt
@@ -1,0 +1,46 @@
+package com.example.localchat
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import java.net.DatagramPacket
+import java.net.DatagramSocket
+import java.net.InetAddress
+import java.net.InetSocketAddress
+
+/**
+ * Simple service for sending and receiving UDP broadcast messages within the local network.
+ */
+class UdpBroadcastService(private val port: Int) {
+    private val socket = DatagramSocket(null)
+    private var job: Job? = null
+
+    init {
+        socket.reuseAddress = true
+        socket.bind(InetSocketAddress(port))
+    }
+
+    fun send(message: String) {
+        val data = message.toByteArray()
+        val packet = DatagramPacket(data, data.size, InetAddress.getByName("255.255.255.255"), port)
+        socket.send(packet)
+    }
+
+    fun startListening(onMessage: (String) -> Unit) {
+        job = CoroutineScope(Dispatchers.IO).launch {
+            val buffer = ByteArray(1024)
+            while (true) {
+                val packet = DatagramPacket(buffer, buffer.size)
+                socket.receive(packet)
+                val text = String(packet.data, 0, packet.length)
+                onMessage(text)
+            }
+        }
+    }
+
+    fun stop() {
+        job?.cancel()
+        socket.close()
+    }
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".MainActivity">
+
+    <!-- TODO: Add UI elements for chat -->
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,0 +1,9 @@
+<resources>
+    <color name="purple_200">#BB86FC</color>
+    <color name="purple_500">#6200EE</color>
+    <color name="purple_700">#3700B3</color>
+    <color name="teal_200">#03DAC5</color>
+    <color name="teal_700">#018786</color>
+    <color name="black">#000000</color>
+    <color name="white">#FFFFFF</color>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">LocalChat</string>
+</resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,0 +1,10 @@
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <style name="Theme.LocalChat" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
+        <item name="colorPrimary">@color/purple_500</item>
+        <item name="colorPrimaryVariant">@color/purple_700</item>
+        <item name="colorOnPrimary">@color/white</item>
+        <item name="colorSecondary">@color/teal_200</item>
+        <item name="colorSecondaryVariant">@color/teal_700</item>
+        <item name="colorOnSecondary">@color/black</item>
+    </style>
+</resources>

--- a/app/src/test/java/com/example/localchat/UdpBroadcastServiceTest.kt
+++ b/app/src/test/java/com/example/localchat/UdpBroadcastServiceTest.kt
@@ -1,0 +1,21 @@
+package com.example.localchat
+
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class UdpBroadcastServiceTest {
+    @Test
+    fun sendAndReceive() = runBlocking {
+        val service = UdpBroadcastService(9999)
+        var received: String? = null
+        service.startListening { message ->
+            received = message
+        }
+        service.send("hello")
+        delay(100)
+        service.stop()
+        assertEquals("hello", received)
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,20 @@
+// Top-level build file where you can add configuration options common to all sub-projects/modules.
+
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath "com.android.tools.build:gradle:8.0.2"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.21"
+    }
+}
+
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,2 @@
+rootProject.name = "LocalChat"
+include(":app")


### PR DESCRIPTION
## Summary
- scaffold Android project for a local-network chat app
- document development workflow in `AGENTS.md`
- create `HISTORY.md` for recording changes
- outline project roadmap in `README`
- add basic UDP broadcast service and tests
- fix Gradle namespace configuration

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f8ea43ae88325919a66a8c92ff5b2