### PR TITLE
Fix artifact action deprecation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Build debug APK
         run: ./gradlew assembleDebug
       - name: Upload APK
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: app-debug-apk
           path: app/build/outputs/apk/debug/app-debug.apk

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 - Added GitHub Actions workflow to build APK and upload it as an artifact.
+- Updated workflow to use `actions/upload-artifact@v4` after deprecation of v3.
 - Introduced Gradle wrapper scripts and ignored the wrapper jar.
 - Initial project scaffold for LocalChat Android app.
 - Added best practices for AI agents in `AGENTS.md`.


### PR DESCRIPTION
## Summary
- update workflow to use `actions/upload-artifact@v4`
- note the workflow change in HISTORY

## Testing
- `./gradlew test` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_684fa7067fac8325a7820db75bb5e5fa