### PR TITLE
Implement basic LAN chat UI

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,7 @@
 # Project History
 
 ## [Unreleased]
+- Added simple chat UI and ChatManager with unit test.
 - Enabled AndroidX to fix GitHub Actions build.
 - Updated AndroidManifest for Android 12 compatibility.
 - Bumped Java compatibility to 17 and updated toolchains.

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:allowBackup="true"
         android:label="@string/app_name"

--- a/app/src/main/java/com/example/localchat/ChatManager.kt
+++ b/app/src/main/java/com/example/localchat/ChatManager.kt
@@ -1,0 +1,19 @@
+package com.example.localchat
+
+class ChatManager(private val service: UdpBroadcastService) {
+    private val _messages = mutableListOf<String>()
+    val messages: List<String> get() = _messages
+
+    fun start() {
+        service.startListening { msg -> _messages.add(msg) }
+    }
+
+    fun stop() {
+        service.stop()
+    }
+
+    fun send(message: String) {
+        service.send(message)
+        _messages.add(message)
+    }
+}

--- a/app/src/main/java/com/example/localchat/MainActivity.kt
+++ b/app/src/main/java/com/example/localchat/MainActivity.kt
@@ -1,11 +1,44 @@
 package com.example.localchat
 
-import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import android.widget.ArrayAdapter
+import android.widget.Button
+import android.widget.EditText
+import android.widget.ListView
+import androidx.appcompat.app.AppCompatActivity
 
 class MainActivity : AppCompatActivity() {
+    private lateinit var service: UdpBroadcastService
+    private lateinit var adapter: ArrayAdapter<String>
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
+
+        val listView = findViewById<ListView>(R.id.messagesList)
+        val input = findViewById<EditText>(R.id.messageInput)
+        val button = findViewById<Button>(R.id.sendButton)
+
+        adapter = ArrayAdapter(this, android.R.layout.simple_list_item_1, mutableListOf())
+        listView.adapter = adapter
+
+        service = UdpBroadcastService(9999)
+        service.startListening { message ->
+            runOnUiThread { adapter.add(message) }
+        }
+
+        button.setOnClickListener {
+            val text = input.text.toString()
+            if (text.isNotBlank()) {
+                service.send(text)
+                adapter.add(text)
+                input.text.clear()
+            }
+        }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        service.stop()
     }
 }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,11 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".MainActivity">
+    android:orientation="vertical">
 
-    <!-- TODO: Add UI elements for chat -->
+    <ListView
+        android:id="@+id/messagesList"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1" />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+    <EditText
+        android:id="@+id/messageInput"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="Enter message" />
+
+    <Button
+        android:id="@+id/sendButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Send" />
+</LinearLayout>

--- a/app/src/test/java/com/example/localchat/ChatManagerTest.kt
+++ b/app/src/test/java/com/example/localchat/ChatManagerTest.kt
@@ -1,0 +1,20 @@
+package com.example.localchat
+
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.net.InetAddress
+
+class ChatManagerTest {
+    @Test
+    fun sendAndReceive() = runBlocking {
+        val service = UdpBroadcastService(9999, InetAddress.getByName("127.0.0.1"))
+        val manager = ChatManager(service)
+        manager.start()
+        manager.send("test")
+        delay(100)
+        manager.stop()
+        assertTrue(manager.messages.any { it == "test" })
+    }
+}


### PR DESCRIPTION
## Summary
- create `ChatManager` to wrap `UdpBroadcastService`
- expose a minimal `MainActivity` with message list and send box
- update layout with ListView, EditText and Button
- request network permission in manifest
- document changes in `HISTORY.md`
- test `ChatManager` send/receive behavior

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fcbeccbe48325892e08a4d9c08b75