### PR TITLE
Fix crash display screen

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -11,4 +11,6 @@
 - Introduced Gradle wrapper scripts and ignored the wrapper jar.
 - Initial project scaffold for LocalChat Android app.
 - Added best practices for AI agents in `AGENTS.md`.
+- Added e2e test for UDP messaging and fixed crash on message send by declaring INTERNET permission.
+- Display uncaught exceptions in a copyable crash screen before the app exits.
 

--- a/app/src/androidTest/java/com/example/localchat/CrashActivityTest.kt
+++ b/app/src/androidTest/java/com/example/localchat/CrashActivityTest.kt
@@ -1,0 +1,30 @@
+package com.example.localchat
+
+import android.content.Context
+import android.content.Intent
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class CrashActivityTest {
+    @Test
+    fun showsError() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val intent = Intent(context, CrashActivity::class.java).apply {
+            putExtra(CrashActivity.EXTRA_ERROR, "boom")
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        ActivityScenario.launch<CrashActivity>(intent).use {
+            onView(withId(R.id.crashMessage)).check(matches(withText("boom")))
+            onView(withId(R.id.copyButton)).perform(click())
+        }
+    }
+}

--- a/app/src/androidTest/java/com/example/localchat/UdpBroadcastServiceE2ETest.kt
+++ b/app/src/androidTest/java/com/example/localchat/UdpBroadcastServiceE2ETest.kt
@@ -1,0 +1,22 @@
+package com.example.localchat
+
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import androidx.test.ext.junit.runners.AndroidJUnit4
+
+@RunWith(AndroidJUnit4::class)
+class UdpBroadcastServiceE2ETest {
+    @Test
+    fun sendAndReceive() = runBlocking {
+        val service = UdpBroadcastService(9999, java.net.InetAddress.getByName("127.0.0.1"))
+        var received: String? = null
+        service.startListening { received = it }
+        service.send("ping")
+        delay(100)
+        service.stop()
+        assertEquals("ping", received)
+    }
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,11 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.INTERNET" />
 
     <application
+        android:name=".LocalChatApplication"
         android:allowBackup="true"
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/Theme.AppCompat.Light.DarkActionBar">
+        <activity android:name=".CrashActivity" android:exported="false" />
         <activity android:name=".MainActivity" android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/com/example/localchat/CrashActivity.kt
+++ b/app/src/main/java/com/example/localchat/CrashActivity.kt
@@ -1,0 +1,34 @@
+package com.example.localchat
+
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.os.Bundle
+import android.widget.Button
+import android.widget.TextView
+import androidx.appcompat.app.AppCompatActivity
+import kotlin.system.exitProcess
+
+class CrashActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_crash)
+
+        val errorText = intent.getStringExtra(EXTRA_ERROR) ?: "Unknown error"
+        findViewById<TextView>(R.id.crashMessage).text = errorText
+
+        findViewById<Button>(R.id.copyButton).setOnClickListener {
+            val clipboard = getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+            clipboard.setPrimaryClip(ClipData.newPlainText("error", errorText))
+        }
+
+        findViewById<Button>(R.id.closeButton).setOnClickListener {
+            finish()
+            exitProcess(1)
+        }
+    }
+
+    companion object {
+        const val EXTRA_ERROR = "error"
+    }
+}

--- a/app/src/main/java/com/example/localchat/LocalChatApplication.kt
+++ b/app/src/main/java/com/example/localchat/LocalChatApplication.kt
@@ -1,0 +1,22 @@
+package com.example.localchat
+
+import android.app.Application
+import android.content.Intent
+import android.os.Handler
+import android.os.Looper
+
+class LocalChatApplication : Application() {
+    override fun onCreate() {
+        super.onCreate()
+        Thread.setDefaultUncaughtExceptionHandler { _, throwable ->
+            val intent = Intent(this, CrashActivity::class.java).apply {
+                putExtra(CrashActivity.EXTRA_ERROR, throwable.stackTraceToString())
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+            }
+            startActivity(intent)
+            Handler(Looper.getMainLooper()).postDelayed({
+                android.os.Process.killProcess(android.os.Process.myPid())
+            }, 1000)
+        }
+    }
+}

--- a/app/src/main/res/layout/activity_crash.xml
+++ b/app/src/main/res/layout/activity_crash.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <TextView
+        android:id="@+id/crashMessage"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:textIsSelectable="true" />
+
+    <Button
+        android:id="@+id/copyButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Copy" />
+
+    <Button
+        android:id="@+id/closeButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Close" />
+</LinearLayout>


### PR DESCRIPTION
## Summary
- show crash message on screen with copy & close buttons
- start CrashActivity from global exception handler
- test CrashActivity via instrumentation
- record crash screen fix in HISTORY

## Testing
- `gradle test` *(fails: SDK location not found)*
- `gradle connectedAndroidTest` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685140bb6648832584a9be1c3001ecfb