### PR TITLE
Use version in APK file name

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,10 @@ jobs:
         run: chmod +x gradlew
       - name: Build debug APK
         run: ./gradlew assembleDebug
+      - name: Get version
+        run: echo "VERSION=$(./gradlew -q printVersion)" >> $GITHUB_ENV
+      - name: Rename APK with version
+        run: mv app/build/outputs/apk/debug/app-debug.apk app/build/outputs/apk/debug/app-debug-$VERSION.apk
       - name: Run unit tests
         if: github.event_name == 'push'
         run: ./gradlew test
@@ -27,5 +31,14 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: app-debug-apk
-          path: app/build/outputs/apk/debug/app-debug.apk
+          path: app/build/outputs/apk/debug/app-debug-$VERSION.apk
+      - name: Send APK to Telegram
+        if: github.event_name == 'push'
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+        run: |
+          curl -s -X POST https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendDocument \
+            -F chat_id=${TELEGRAM_CHAT_ID} \
+            -F document=@app/build/outputs/apk/debug/app-debug-$VERSION.apk
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -8,6 +8,8 @@
 - Fixed lint issues and added safer UDP test configuration.
 - Added GitHub Actions workflow to build APK and upload it as an artifact.
 - Updated workflow to use `actions/upload-artifact@v4` after deprecation of v3.
+- Added Telegram step in CI to send the APK to a chat using secrets.
+- CI now names the APK with its version when uploading and sending to Telegram.
 - Introduced Gradle wrapper scripts and ignored the wrapper jar.
 - Initial project scaffold for LocalChat Android app.
 - Added best practices for AI agents in `AGENTS.md`.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -19,8 +19,8 @@ android {
         applicationId "com.example.localchat"
         minSdk 21
         targetSdk 33
-        versionCode 1
-        versionName "1.0"
+        versionCode 3
+        versionName "1.2"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
@@ -29,6 +29,13 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
+    }
+}
+
+// Task to print the current version name for CI scripts
+tasks.register("printVersion") {
+    doLast {
+        println(android.defaultConfig.versionName)
     }
 }
 


### PR DESCRIPTION
## Summary
- put app version in the built APK filename during CI
- expose version via `printVersion` gradle task
- bump app version to 1.2 and document workflow change

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68524c6f22c08325b6272a96a3a54da5