### PR TITLE
Implement basic chat UI

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -15,4 +15,5 @@
 - Added best practices for AI agents in `AGENTS.md`.
 - Added e2e test for UDP messaging and fixed crash on message send by declaring INTERNET permission.
 - Display uncaught exceptions in a copyable crash screen before the app exits.
+- Implemented basic chat UI using UDP broadcast messages.
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ LocalChat is an Android application for chatting over a local network using UDP 
 ## Getting Started
 1. Open the project in Android Studio.
 2. Build and run on devices within the same local network.
+3. Use the simple chat screen to send messages that appear on all peers.
 
 ## Development Guidelines
 - Follow the principles in `AGENTS.md`.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -19,8 +19,8 @@ android {
         applicationId "com.example.localchat"
         minSdk 21
         targetSdk 33
-        versionCode 3
-        versionName "1.2"
+        versionCode 4
+        versionName "1.3"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/androidTest/java/com/example/localchat/ChatUiTest.kt
+++ b/app/src/androidTest/java/com/example/localchat/ChatUiTest.kt
@@ -1,0 +1,37 @@
+package com.example.localchat
+
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.closeSoftKeyboard
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.action.ViewActions.typeText
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/** Instrumented tests for the basic chat UI. */
+@RunWith(AndroidJUnit4::class)
+class ChatUiTest {
+
+    @get:Rule
+    val rule = ActivityScenarioRule(MainActivity::class.java)
+
+    @Test
+    fun sendMessageShowsInList() {
+        onView(withId(R.id.messageInput)).perform(typeText("hi"), closeSoftKeyboard())
+        onView(withId(R.id.sendButton)).perform(click())
+        onView(withText("hi")).check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun receiveMessageShowsInList() {
+        rule.scenario.onActivity { it.onMessageReceived("hello") }
+        onView(withText("hello")).check(matches(isDisplayed()))
+    }
+}
+

--- a/app/src/main/java/com/example/localchat/MainActivity.kt
+++ b/app/src/main/java/com/example/localchat/MainActivity.kt
@@ -1,11 +1,47 @@
 package com.example.localchat
 
-import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import android.widget.ArrayAdapter
+import android.widget.Button
+import android.widget.EditText
+import android.widget.ListView
+import androidx.appcompat.app.AppCompatActivity
 
 class MainActivity : AppCompatActivity() {
+
+    private lateinit var service: UdpBroadcastService
+    private lateinit var adapter: ArrayAdapter<String>
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
+
+        val listView = findViewById<ListView>(R.id.messageList)
+        val input = findViewById<EditText>(R.id.messageInput)
+        val send = findViewById<Button>(R.id.sendButton)
+
+        adapter = ArrayAdapter(this, android.R.layout.simple_list_item_1, mutableListOf())
+        listView.adapter = adapter
+
+        service = UdpBroadcastService(9999)
+        service.startListening { onMessageReceived(it) }
+
+        send.setOnClickListener {
+            val text = input.text.toString()
+            if (text.isNotEmpty()) {
+                service.send(text)
+                onMessageReceived(text)
+                input.text.clear()
+            }
+        }
+    }
+
+    fun onMessageReceived(message: String) {
+        runOnUiThread { adapter.add(message) }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        service.stop()
     }
 }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,11 +1,33 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".MainActivity">
+    android:padding="16dp">
 
-    <!-- TODO: Add UI elements for chat -->
+    <ListView
+        android:id="@+id/messageList"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1" />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+        <EditText
+            android:id="@+id/messageInput"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:hint="Message" />
+
+        <Button
+            android:id="@+id/sendButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Send" />
+    </LinearLayout>
+
+</LinearLayout>


### PR DESCRIPTION
## Summary
- implement a chat interface in `MainActivity`
- render the chat list in `activity_main.xml`
- add instrumentation tests for chatting
- bump to version 1.3
- document the new chat feature

## Testing
- `gradle test` *(fails: SDK location not found)*
- `gradle connectedAndroidTest` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685255d57f848325982435b562e32f47