### PR TITLE
Add username drawer with timestamps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,4 +41,7 @@ jobs:
           curl -s -X POST https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendDocument \
             -F chat_id=${TELEGRAM_CHAT_ID} \
             -F document=@app/build/outputs/apk/debug/app-debug-$VERSION.apk
+          curl -s -X POST https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage \
+            -d chat_id=${TELEGRAM_CHAT_ID} \
+            -d text="Built version $VERSION. Install and verify chat names and timestamps."
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -17,4 +17,6 @@
 - Display uncaught exceptions in a copyable crash screen before the app exits.
 - Implemented basic chat UI using UDP broadcast messages.
 - Fixed NetworkOnMainThreadException by sending UDP messages on a background thread.
+- Added username settings drawer, message timestamps, and sender names with IP fallback.
+- Bumped app version to 1.5.
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -19,8 +19,8 @@ android {
         applicationId "com.example.localchat"
         minSdk 21
         targetSdk 33
-        versionCode 5
-        versionName "1.4"
+        versionCode 6
+        versionName "1.5"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/androidTest/java/com/example/localchat/ChatUiTest.kt
+++ b/app/src/androidTest/java/com/example/localchat/ChatUiTest.kt
@@ -8,6 +8,7 @@ import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
+import org.hamcrest.CoreMatchers.containsString
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Rule
@@ -25,13 +26,13 @@ class ChatUiTest {
     fun sendMessageShowsInList() {
         onView(withId(R.id.messageInput)).perform(typeText("hi"), closeSoftKeyboard())
         onView(withId(R.id.sendButton)).perform(click())
-        onView(withText("hi")).check(matches(isDisplayed()))
+        onView(withText(containsString("hi"))).check(matches(isDisplayed()))
     }
 
     @Test
     fun receiveMessageShowsInList() {
-        rule.scenario.onActivity { it.onMessageReceived("hello") }
-        onView(withText("hello")).check(matches(isDisplayed()))
+        rule.scenario.onActivity { it.onMessageReceived(java.net.InetAddress.getLoopbackAddress(), ChatMessage(null, "hello", System.currentTimeMillis()).toJson()) }
+        onView(withText(containsString("hello"))).check(matches(isDisplayed()))
     }
 }
 

--- a/app/src/androidTest/java/com/example/localchat/UdpBroadcastServiceE2ETest.kt
+++ b/app/src/androidTest/java/com/example/localchat/UdpBroadcastServiceE2ETest.kt
@@ -13,7 +13,7 @@ class UdpBroadcastServiceE2ETest {
     fun sendAndReceive() = runBlocking {
         val service = UdpBroadcastService(9999, java.net.InetAddress.getByName("127.0.0.1"))
         var received: String? = null
-        service.startListening { received = it }
+        service.startListening { _, m -> received = m }
         service.send("ping")
         delay(100)
         service.stop()

--- a/app/src/main/java/com/example/localchat/ChatMessage.kt
+++ b/app/src/main/java/com/example/localchat/ChatMessage.kt
@@ -1,0 +1,32 @@
+package com.example.localchat
+
+import org.json.JSONObject
+
+/** Simple data model for chat messages. */
+data class ChatMessage(
+    val name: String?,
+    val text: String,
+    val timestamp: Long
+) {
+    fun toJson(): String = JSONObject().apply {
+        put("name", name)
+        put("text", text)
+        put("time", timestamp)
+    }.toString()
+
+    companion object {
+        fun fromJson(json: String): ChatMessage {
+            return try {
+                val obj = JSONObject(json)
+                ChatMessage(
+                    obj.optString("name", null),
+                    obj.getString("text"),
+                    obj.optLong("time", System.currentTimeMillis())
+                )
+            } catch (e: Exception) {
+                // Fallback for plain text messages
+                ChatMessage(null, json, System.currentTimeMillis())
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/localchat/MainActivity.kt
+++ b/app/src/main/java/com/example/localchat/MainActivity.kt
@@ -1,16 +1,26 @@
 package com.example.localchat
 
+import android.content.SharedPreferences
 import android.os.Bundle
+import android.view.Gravity
 import android.widget.ArrayAdapter
 import android.widget.Button
 import android.widget.EditText
 import android.widget.ListView
+import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
+import androidx.drawerlayout.widget.DrawerLayout
+import java.net.InetAddress
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 
 class MainActivity : AppCompatActivity() {
 
     private lateinit var service: UdpBroadcastService
     private lateinit var adapter: ArrayAdapter<String>
+    private lateinit var prefs: SharedPreferences
+    private lateinit var drawer: DrawerLayout
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -19,25 +29,48 @@ class MainActivity : AppCompatActivity() {
         val listView = findViewById<ListView>(R.id.messageList)
         val input = findViewById<EditText>(R.id.messageInput)
         val send = findViewById<Button>(R.id.sendButton)
+        val menu = findViewById<Button>(R.id.menuButton)
+        drawer = findViewById(R.id.drawerLayout)
+        val nameInput = findViewById<EditText>(R.id.nameInput)
+        val saveName = findViewById<Button>(R.id.saveNameButton)
+
+        prefs = getSharedPreferences("prefs", MODE_PRIVATE)
+        nameInput.setText(prefs.getString("name", ""))
+
+        menu.setOnClickListener { drawer.openDrawer(Gravity.END) }
+        saveName.setOnClickListener {
+            prefs.edit().putString("name", nameInput.text.toString()).apply()
+            drawer.closeDrawer(Gravity.END)
+        }
 
         adapter = ArrayAdapter(this, android.R.layout.simple_list_item_1, mutableListOf())
         listView.adapter = adapter
 
+        if (prefs.getString("name", null).isNullOrEmpty()) {
+            drawer.openDrawer(Gravity.END)
+        }
+
         service = UdpBroadcastService(9999)
-        service.startListening { onMessageReceived(it) }
+        service.startListening { address, text -> onMessageReceived(address, text) }
 
         send.setOnClickListener {
             val text = input.text.toString()
             if (text.isNotEmpty()) {
-                service.send(text)
-                onMessageReceived(text)
+                val message = ChatMessage(prefs.getString("name", null), text, System.currentTimeMillis())
+                val json = message.toJson()
+                service.send(json)
+                onMessageReceived(InetAddress.getLoopbackAddress(), json)
                 input.text.clear()
             }
         }
     }
 
-    fun onMessageReceived(message: String) {
-        runOnUiThread { adapter.add(message) }
+    fun onMessageReceived(address: InetAddress, json: String) {
+        val msg = ChatMessage.fromJson(json)
+        val name = msg.name?.takeIf { it.isNotBlank() } ?: address.hostAddress
+        val time = SimpleDateFormat("HH:mm:ss", Locale.getDefault()).format(Date(msg.timestamp))
+        val display = "$name: ${'$'}{msg.text} [${'$'}time]"
+        runOnUiThread { adapter.add(display) }
     }
 
     override fun onDestroy() {

--- a/app/src/main/java/com/example/localchat/UdpBroadcastService.kt
+++ b/app/src/main/java/com/example/localchat/UdpBroadcastService.kt
@@ -31,14 +31,14 @@ class UdpBroadcastService(private val port: Int, private val address: InetAddres
         }
     }
 
-    fun startListening(onMessage: (String) -> Unit) {
+    fun startListening(onMessage: (InetAddress, String) -> Unit) {
         job = CoroutineScope(Dispatchers.IO).launch {
             val buffer = ByteArray(1024)
             while (true) {
                 val packet = DatagramPacket(buffer, buffer.size)
                 socket.receive(packet)
                 val text = String(packet.data, 0, packet.length)
-                onMessage(text)
+                onMessage(packet.address, text)
             }
         }
     }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,33 +1,66 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:orientation="vertical"
+<androidx.drawerlayout.widget.DrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/drawerLayout"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:padding="16dp">
-
-    <ListView
-        android:id="@+id/messageList"
-        android:layout_width="match_parent"
-        android:layout_height="0dp"
-        android:layout_weight="1" />
+    android:layout_height="match_parent">
 
     <LinearLayout
+        android:orientation="vertical"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal">
-
-        <EditText
-            android:id="@+id/messageInput"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:hint="Message" />
+        android:layout_height="match_parent"
+        android:padding="16dp">
 
         <Button
-            android:id="@+id/sendButton"
+            android:id="@+id/menuButton"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="Send" />
+            android:text="Menu" />
+
+        <ListView
+            android:id="@+id/messageList"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <EditText
+                android:id="@+id/messageInput"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:hint="Message" />
+
+            <Button
+                android:id="@+id/sendButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Send" />
+        </LinearLayout>
     </LinearLayout>
 
-</LinearLayout>
+    <LinearLayout
+        android:id="@+id/drawer"
+        android:layout_width="240dp"
+        android:layout_height="match_parent"
+        android:layout_gravity="end"
+        android:orientation="vertical"
+        android:padding="16dp">
+
+        <EditText
+            android:id="@+id/nameInput"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="Name" />
+
+        <Button
+            android:id="@+id/saveNameButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Save" />
+    </LinearLayout>
+
+</androidx.drawerlayout.widget.DrawerLayout>

--- a/app/src/test/java/com/example/localchat/UdpBroadcastServiceTest.kt
+++ b/app/src/test/java/com/example/localchat/UdpBroadcastServiceTest.kt
@@ -11,7 +11,7 @@ class UdpBroadcastServiceTest {
     fun sendAndReceive() = runBlocking {
         val service = UdpBroadcastService(9999, InetAddress.getByName("127.0.0.1"))
         var received: String? = null
-        service.startListening { message ->
+        service.startListening { _, message ->
             received = message
         }
         service.send("hello")


### PR DESCRIPTION
## Summary
- implement user name persistence and editable settings drawer
- display names, timestamps, and IP fallback for chat messages
- update build workflow to send a text message along with APK
- bump version to 1.5

## Testing
- `gradle wrapper`
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685265c8ee948325838294c99c1cb298