### PR TITLE
Fix duplicate self messages and formatting

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,7 @@
 # Project History
 
 ## [Unreleased]
+- Fixed chat messages showing `$time` and `$text` and removed duplicates by avoiding handling our own broadcasts.
 - Enabled AndroidX to fix GitHub Actions build.
 - Updated AndroidManifest for Android 12 compatibility.
 - Bumped Java compatibility to 17 and updated toolchains.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -19,8 +19,8 @@ android {
         applicationId "com.example.localchat"
         minSdk 21
         targetSdk 33
-        versionCode 6
-        versionName "1.5"
+        versionCode 7
+        versionName "1.6"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/com/example/localchat/MainActivity.kt
+++ b/app/src/main/java/com/example/localchat/MainActivity.kt
@@ -59,7 +59,6 @@ class MainActivity : AppCompatActivity() {
                 val message = ChatMessage(prefs.getString("name", null), text, System.currentTimeMillis())
                 val json = message.toJson()
                 service.send(json)
-                onMessageReceived(InetAddress.getLoopbackAddress(), json)
                 input.text.clear()
             }
         }
@@ -69,7 +68,7 @@ class MainActivity : AppCompatActivity() {
         val msg = ChatMessage.fromJson(json)
         val name = msg.name?.takeIf { it.isNotBlank() } ?: address.hostAddress
         val time = SimpleDateFormat("HH:mm:ss", Locale.getDefault()).format(Date(msg.timestamp))
-        val display = "$name: ${'$'}{msg.text} [${'$'}time]"
+        val display = "$name: ${msg.text} [$time]"
         runOnUiThread { adapter.add(display) }
     }
 


### PR DESCRIPTION
## Summary
- stop manually echoing our own broadcast messages
- fix chat message formatting string
- bump app version to 1.6
- document change in HISTORY

## Testing
- `gradle test --no-daemon --stacktrace` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852dad0b7e48325bdc893f7437e7373